### PR TITLE
複数ファイルの変換に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ $ litto ./foo.md
 
 ```sh
 $ litto --write ./hoge.md
+hoge.md
+Done.
 ```
 
 また、`--format`オプションを使うことで、[Prettier](https://github.com/prettier/prettier)によるフォーマットをかけることができます。

--- a/jest.json
+++ b/jest.json
@@ -1,6 +1,6 @@
 {
   "testEnvironment": "node",
-  "testRegex": "(/__tests__/.*|\\.spec)\\.(js)$",
+  "testRegex": "(/**tests**/.\*|\\.spec)\\.(js)$",
   "moduleFileExtensions": ["js", "json"],
   "rootDir": "./"
 }

--- a/jest.json
+++ b/jest.json
@@ -1,6 +1,6 @@
 {
   "testEnvironment": "node",
-  "testRegex": "(/**tests**/.\*|\\.spec)\\.(js)$",
+  "testRegex": "(/__tests__/.*|\\.spec)\\.(js)$",
   "moduleFileExtensions": ["js", "json"],
   "rootDir": "./"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "rollup -c -w",
     "build": "rollup -c",
-    "format": "prettier --write ./**/**.{js,ts,md,json}",
+    "format": "prettier --write \"{,src/**/}*.{js,md,json}\"",
     "lint": "eslint ./ --ext ts",
     "lint:fix": "yarn lint --fix",
     "test": "jest",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const program = require("commander");
-const fs = require("fs");
 const colors = require("colors/safe");
 const litto = require("../litto").litto;
 const writeFileContent = require("./utils/writeFileContent").writeFileContent;

--- a/src/cli/utils/writeFileContent.js
+++ b/src/cli/utils/writeFileContent.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const fs = require("fs");
+
+function createError(filename, error) {
+  return new Error(`Unable to write ${filename}: ${error.message}`);
+}
+
+function writeFileContent(filename, content) {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filename, content, "utf8", error => {
+      if (error && error.code !== "ENOENT") {
+        reject(createError(filename, error));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+module.exports = {
+  writeFileContent
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,6 +789,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colors@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"


### PR DESCRIPTION
今まで１つのファイルに対してのみ変換を走らせることができたので、複数のファイルでも変換できるように対応。

```
$ litto --write **.md
bar.md
foo.md
Done
```